### PR TITLE
Disable animation of parent hierarchy

### DIFF
--- a/app/src/main/java/com/jwo/viewpager2bug/ItemFragment.kt
+++ b/app/src/main/java/com/jwo/viewpager2bug/ItemFragment.kt
@@ -16,6 +16,7 @@ class ItemFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentItemBinding.inflate(inflater, container, false)
+        binding.parent.layoutTransition.setAnimateParentHierarchy(false)
         return binding.root
     }
 


### PR DESCRIPTION
This change will prevent the bug from occurring by disabling animation of the parent hierarchy of the ViewGroup with animateLayoutChanges="true"